### PR TITLE
Remove empty includes field from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,3 @@ paragraph=Schedules coroutines, starts, stops, restarts and wakeups them. Timest
 category=Timing
 url=https://github.com/jmparatte/jm_Scheduler
 architectures=*
-includes=


### PR DESCRIPTION
The `includes` field in library.properties is used to specify which `#include` directives should be added to the sketch via **Sketch > Include Library > jm_scheduler**. This property is useful when a library contains multiple header files but you don't want `#include` directives for all of them added to the sketch. Leaving this field empty causes that action to add the following line to the sketch:
```cpp
#include <>
```
When no `includes` property is present the Arduino IDE adds `#include` directives for all header files in the root of the library. Since this library only contains a single header file it's fine to just omit the `includes` field, which will cause the Arduino IDE to take the correct action by adding the line:
```cpp
#include <jm_Scheduler.h>
```